### PR TITLE
Made widget option 'list' display only a list of language names

### DIFF
--- a/includes/class-wpglobus-widget.php
+++ b/includes/class-wpglobus-widget.php
@@ -126,6 +126,12 @@ class WPGlobusWidget extends WP_Widget {
 					$inside .= '<span class="flag"><a href="' . $url . '"><img src="' . $flag . '"/></a></span>';
 					break;
 				case 'list' :
+					$inside .= '<a href="' . $url . '">' .
+						         '<span class="name">' .
+					           WPGlobus::Config()->language_name[ $language ] .
+                     '</span>' . 
+                     '</a>';
+        	break;
 				case 'list_with_flags' :
 					$inside .= '<a href="' . $url . '">' .
 					           '<img src="' . $flag . '" alt=""/>' .


### PR DESCRIPTION
In the WPGlobus Widget, 'List' and 'List With Flag' have the same result: a language list with the Flag, Country Code, and Language of each language displayed. Both cases produce the same output for the $inside variable.

This isn't what I wanted or expected. A list should be just that--a list. With flags should show that same list with flags. So I separated the cases and gave 'List' output of the link and a span with the language name. 

For better styling I also added a CSS rule to my personal tweaks:
```
.list a + a::before {
	content: " / ";
}
```
However, I left this out of the pull request in order to leave that bit of styling up to the user.