### PR TITLE
Disable wordpress auto formatting if needed

### DIFF
--- a/includes/class-wpglobus.php
+++ b/includes/class-wpglobus.php
@@ -1272,7 +1272,11 @@ class WPGlobus {
 			 * added 24.05.2015
 			 * @todo     what's next with wpautop?  @see 'wpautop()' in https://make.wordpress.org/core/2015/05/14/dev-chat-summary-may-13/
 			 */
-			$post_content_autop = wpautop( $post_content );
+			if ( has_filter( 'the_content', 'wpautop' ) ) {
+				$post_content_autop = wpautop( $post_content );
+			} else {
+				$post_content_autop = $post_content;
+			}
 
 			wp_localize_script(
 				'wpglobus-admin',


### PR DESCRIPTION
When I try to disable the wpautop filter by adding
`remove_filter( 'the_content', 'wpautop' );`
`remove_filter( 'the_excerpt', 'wpautop' );`
to my function.php file, as explained [here](https://codex.wordpress.org/Function_Reference/wpautop), it doesn't work because WPGlobus is calling wpautop function anyway.
This change lets WPGlobus check if the filter was removed in function.php. If the filter was removed, it skips the wpautop function call.