### PR TITLE
Fix slash striping on gutenberg editor

### DIFF
--- a/includes/builders/gutenberg/class-wpglobus-gutenberg-update-post.php
+++ b/includes/builders/gutenberg/class-wpglobus-gutenberg-update-post.php
@@ -246,7 +246,7 @@ if ( ! class_exists( 'WPGlobus_Gutenberg_Update_Post' ) ) :
 
 				endforeach;
 
-				$prepared_post->$field = WPGlobus_Utils::build_multilingual_string( $tr );
+				$prepared_post->$field = wp_slash( WPGlobus_Utils::build_multilingual_string( $tr ) );
 
 			}
 


### PR DESCRIPTION
This PR fixes the problem with WPGlobus stripping slashes from posts and pages in the gutenberg editor. When returning data from a `rest_pre_insert_post` filter, wordpress expects the fields to be "slashed". Since WPGlobus is recreating all those fields, they need to be passed through `wp_slash`.

I got the idea on how to fix this problem from this link: https://wordpress.stackexchange.com/a/331128

They reference this [piece of code](https://github.com/WordPress/WordPress/blob/ed11103f39e2a5736caf09eb9d76bb6711702c04/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L687).

A quick way to test this is to add slashes to the title of a page or any block in a post and save. After reloading the slashes are gone without this patch.